### PR TITLE
Introduce `StorageProvider`

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod storage;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod storage;
+pub mod metrics;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -11,11 +11,10 @@ use tokio::sync::RwLock;
 use tonic::{transport::Server, Request, Response, Status};
 use tower_http::cors::{Any, CorsLayer};
 
-// Define InMemoryStorage
+use backend::storage::InMemoryStorage;
+
 #[derive(Debug, Default)]
-struct InMemoryStorage {
-    bool_flags: RwLock<HashMap<String, BoolFlag>>,
-    string_flags: RwLock<HashMap<String, StringFlag>>,
+struct MetricsProvider {
     metrics: RwLock<HashMap<String, MetricsData>>,
 }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -16,7 +16,7 @@ use backend::metrics::prelude::{InMemoryMetricsProvider, VariantType};
 
 #[derive(Debug)]
 struct AkashaFlagService {
-    storage: Arc<InMemoryStorage>,
+    storage: Arc<dyn StorageProvider>,
 }
 
 #[tonic::async_trait]
@@ -166,7 +166,7 @@ impl FlagService for AkashaFlagService {
 // Implement EvaluationService
 #[derive(Debug)]
 struct AkashaEvaluationService {
-    storage: Arc<InMemoryStorage>,
+    storage: Arc<dyn StorageProvider>,
     metrics: Arc<Mutex<InMemoryMetricsProvider>>,
 }
 
@@ -354,7 +354,7 @@ impl MetricsService for AkashaMetricsService {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "0.0.0.0:50051".parse()?;
-    let storage = Arc::new(InMemoryStorage::default());
+    let storage: Arc<dyn StorageProvider> = Arc::new(InMemoryStorage::default());
     let metrics = Arc::new(Mutex::new(InMemoryMetricsProvider::default()));
 
     let flag_service = FlagServiceServer::new(AkashaFlagService {

--- a/backend/src/metrics/mod.rs
+++ b/backend/src/metrics/mod.rs
@@ -1,0 +1,1 @@
+pub mod prelude;

--- a/backend/src/metrics/prelude.rs
+++ b/backend/src/metrics/prelude.rs
@@ -1,0 +1,96 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use tokio::sync::RwLock;
+
+#[derive(Debug, Default, Clone)]
+pub struct MetricsData {
+    total_queries: i64,
+    variant_counts: HashMap<VariantType, i64>,
+}
+
+impl MetricsData {
+    pub fn new() -> Self {
+        Self {
+            total_queries: 0,
+            variant_counts: HashMap::new(),
+        }
+    }
+
+    pub fn increment_variant(&mut self, variant: VariantType) {
+        self.total_queries += 1;
+
+        let count = self.variant_counts.entry(variant).or_insert(0);
+        *count += 1;
+    }
+
+    pub fn get_total_queries(&self) -> i64 {
+        self.total_queries
+    }
+
+    pub fn get_variants(&self) -> &HashMap<VariantType, i64> {
+        &self.variant_counts
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum VariantType {
+    BoolVariant(bool),
+    StringVariant(String),
+}
+
+impl From<VariantType> for String {
+    fn from(val: VariantType) -> Self {
+        match val {
+            VariantType::BoolVariant(value) => value.to_string(),
+            VariantType::StringVariant(value) => value,
+        }
+    }
+}
+
+impl From<bool> for VariantType {
+    fn from(value: bool) -> Self {
+        VariantType::BoolVariant(value)
+    }
+}
+
+impl From<String> for VariantType {
+    fn from(value: String) -> Self {
+        VariantType::StringVariant(value)
+    }
+}
+
+impl From<&str> for VariantType {
+    fn from(value: &str) -> Self {
+        VariantType::StringVariant(value.to_string())
+    }
+}
+
+#[derive(Debug)]
+pub struct InMemoryMetricsProvider {
+    flags: RwLock<HashMap<String, MetricsData>>,
+}
+
+impl InMemoryMetricsProvider {
+    pub fn new() -> Self {
+        Self {
+            flags: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub async fn get_metrics(&self, flag_id: &str) -> Option<MetricsData> {
+        self.flags.read().await.get(flag_id).cloned()
+    }
+
+    pub async fn increment_variant(&mut self, flag_id: &str, variant: VariantType) {
+        let mut flags_writer = self.flags.write().await;
+        let data = flags_writer.entry(flag_id.to_string()).or_default();
+        data.increment_variant(variant);
+    }
+}
+
+impl Default for InMemoryMetricsProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/backend/src/storage/in_memory.rs
+++ b/backend/src/storage/in_memory.rs
@@ -1,3 +1,5 @@
+// src/storage/in_memory.rs
+
 use proto::gen::*;
 use std::collections::HashMap;
 use tokio::sync::RwLock;
@@ -5,6 +7,104 @@ use tokio::sync::RwLock;
 // Define InMemoryStorage
 #[derive(Debug, Default)]
 pub struct InMemoryStorage {
+    // Private fields
     bool_flags: RwLock<HashMap<String, BoolFlag>>,
     string_flags: RwLock<HashMap<String, StringFlag>>,
+}
+
+// Implement methods for InMemoryStorage
+impl InMemoryStorage {
+    // BoolFlag methods
+    pub async fn create_bool_flag(&self, flag: BoolFlag) -> Result<(), String> {
+        let mut flags = self.bool_flags.write().await;
+        if flags.contains_key(&flag.id) {
+            Err("BoolFlag with this ID already exists.".to_string())
+        } else {
+            flags.insert(flag.id.clone(), flag);
+            Ok(())
+        }
+    }
+
+    pub async fn get_bool_flag(&self, id: &str) -> Option<BoolFlag> {
+        let flags = self.bool_flags.read().await;
+        flags.get(id).cloned()
+    }
+
+    pub async fn get_bool_flag_by_name(&self, name: &str) -> Option<BoolFlag> {
+        let flags = self.bool_flags.read().await;
+        flags.values().find(|flag| flag.name == name).cloned()
+    }
+
+    pub async fn update_bool_flag(&self, flag: BoolFlag) -> Result<(), String> {
+        let mut flags = self.bool_flags.write().await;
+        if flags.contains_key(&flag.id) {
+            flags.insert(flag.id.clone(), flag);
+            Ok(())
+        } else {
+            Err("BoolFlag not found.".to_string())
+        }
+    }
+
+    pub async fn delete_bool_flag(&self, id: &str) -> bool {
+        let mut flags = self.bool_flags.write().await;
+        flags.remove(id).is_some()
+    }
+
+    pub async fn list_bool_flags(&self, page: usize, page_size: usize) -> (Vec<BoolFlag>, i32) {
+        let flags = self.bool_flags.read().await;
+        let flags_vec: Vec<BoolFlag> = flags.values().cloned().collect();
+        let total_count = flags_vec.len() as i32;
+
+        let start = page * page_size;
+        let flags_page = flags_vec.into_iter().skip(start).take(page_size).collect();
+
+        (flags_page, total_count)
+    }
+
+    // StringFlag methods
+    pub async fn create_string_flag(&self, flag: StringFlag) -> Result<(), String> {
+        let mut flags = self.string_flags.write().await;
+        if flags.contains_key(&flag.id) {
+            Err("StringFlag with this ID already exists.".to_string())
+        } else {
+            flags.insert(flag.id.clone(), flag);
+            Ok(())
+        }
+    }
+
+    pub async fn get_string_flag(&self, id: &str) -> Option<StringFlag> {
+        let flags = self.string_flags.read().await;
+        flags.get(id).cloned()
+    }
+
+    pub async fn get_string_flag_by_name(&self, name: &str) -> Option<StringFlag> {
+        let flags = self.string_flags.read().await;
+        flags.values().find(|flag| flag.name == name).cloned()
+    }
+
+    pub async fn update_string_flag(&self, flag: StringFlag) -> Result<(), String> {
+        let mut flags = self.string_flags.write().await;
+        if flags.contains_key(&flag.id) {
+            flags.insert(flag.id.clone(), flag);
+            Ok(())
+        } else {
+            Err("StringFlag not found.".to_string())
+        }
+    }
+
+    pub async fn delete_string_flag(&self, id: &str) -> bool {
+        let mut flags = self.string_flags.write().await;
+        flags.remove(id).is_some()
+    }
+
+    pub async fn list_string_flags(&self, page: usize, page_size: usize) -> (Vec<StringFlag>, i32) {
+        let flags = self.string_flags.read().await;
+        let flags_vec: Vec<StringFlag> = flags.values().cloned().collect();
+        let total_count = flags_vec.len() as i32;
+
+        let start = page * page_size;
+        let flags_page = flags_vec.into_iter().skip(start).take(page_size).collect();
+
+        (flags_page, total_count)
+    }
 }

--- a/backend/src/storage/in_memory.rs
+++ b/backend/src/storage/in_memory.rs
@@ -3,6 +3,10 @@
 use proto::gen::*;
 use std::collections::HashMap;
 use tokio::sync::RwLock;
+use async_trait::async_trait;
+
+// Import the Storage trait and StorageError
+use crate::storage::prelude::{StorageProvider, StorageError};
 
 // Define InMemoryStorage
 #[derive(Debug, Default)]
@@ -12,45 +16,49 @@ pub struct InMemoryStorage {
     string_flags: RwLock<HashMap<String, StringFlag>>,
 }
 
-// Implement methods for InMemoryStorage
-impl InMemoryStorage {
+#[async_trait]
+impl StorageProvider for InMemoryStorage {
     // BoolFlag methods
-    pub async fn create_bool_flag(&self, flag: BoolFlag) -> Result<(), String> {
+    async fn create_bool_flag(&self, flag: BoolFlag) -> Result<(), StorageError> {
         let mut flags = self.bool_flags.write().await;
         if flags.contains_key(&flag.id) {
-            Err("BoolFlag with this ID already exists.".to_string())
+            Err(StorageError::AlreadyExists)
         } else {
             flags.insert(flag.id.clone(), flag);
             Ok(())
         }
     }
 
-    pub async fn get_bool_flag(&self, id: &str) -> Option<BoolFlag> {
+    async fn get_bool_flag(&self, id: &str) -> Result<Option<BoolFlag>, StorageError> {
         let flags = self.bool_flags.read().await;
-        flags.get(id).cloned()
+        Ok(flags.get(id).cloned())
     }
 
-    pub async fn get_bool_flag_by_name(&self, name: &str) -> Option<BoolFlag> {
+    async fn get_bool_flag_by_name(&self, name: &str) -> Result<Option<BoolFlag>, StorageError> {
         let flags = self.bool_flags.read().await;
-        flags.values().find(|flag| flag.name == name).cloned()
+        Ok(flags.values().find(|flag| flag.name == name).cloned())
     }
 
-    pub async fn update_bool_flag(&self, flag: BoolFlag) -> Result<(), String> {
+    async fn update_bool_flag(&self, flag: BoolFlag) -> Result<(), StorageError> {
         let mut flags = self.bool_flags.write().await;
         if flags.contains_key(&flag.id) {
             flags.insert(flag.id.clone(), flag);
             Ok(())
         } else {
-            Err("BoolFlag not found.".to_string())
+            Err(StorageError::NotFound)
         }
     }
 
-    pub async fn delete_bool_flag(&self, id: &str) -> bool {
+    async fn delete_bool_flag(&self, id: &str) -> Result<bool, StorageError> {
         let mut flags = self.bool_flags.write().await;
-        flags.remove(id).is_some()
+        Ok(flags.remove(id).is_some())
     }
 
-    pub async fn list_bool_flags(&self, page: usize, page_size: usize) -> (Vec<BoolFlag>, i32) {
+    async fn list_bool_flags(
+        &self,
+        page: usize,
+        page_size: usize,
+    ) -> Result<(Vec<BoolFlag>, i32), StorageError> {
         let flags = self.bool_flags.read().await;
         let flags_vec: Vec<BoolFlag> = flags.values().cloned().collect();
         let total_count = flags_vec.len() as i32;
@@ -58,46 +66,50 @@ impl InMemoryStorage {
         let start = page * page_size;
         let flags_page = flags_vec.into_iter().skip(start).take(page_size).collect();
 
-        (flags_page, total_count)
+        Ok((flags_page, total_count))
     }
 
     // StringFlag methods
-    pub async fn create_string_flag(&self, flag: StringFlag) -> Result<(), String> {
+    async fn create_string_flag(&self, flag: StringFlag) -> Result<(), StorageError> {
         let mut flags = self.string_flags.write().await;
         if flags.contains_key(&flag.id) {
-            Err("StringFlag with this ID already exists.".to_string())
+            Err(StorageError::AlreadyExists)
         } else {
             flags.insert(flag.id.clone(), flag);
             Ok(())
         }
     }
 
-    pub async fn get_string_flag(&self, id: &str) -> Option<StringFlag> {
+    async fn get_string_flag(&self, id: &str) -> Result<Option<StringFlag>, StorageError> {
         let flags = self.string_flags.read().await;
-        flags.get(id).cloned()
+        Ok(flags.get(id).cloned())
     }
 
-    pub async fn get_string_flag_by_name(&self, name: &str) -> Option<StringFlag> {
+    async fn get_string_flag_by_name(&self, name: &str) -> Result<Option<StringFlag>, StorageError> {
         let flags = self.string_flags.read().await;
-        flags.values().find(|flag| flag.name == name).cloned()
+        Ok(flags.values().find(|flag| flag.name == name).cloned())
     }
 
-    pub async fn update_string_flag(&self, flag: StringFlag) -> Result<(), String> {
+    async fn update_string_flag(&self, flag: StringFlag) -> Result<(), StorageError> {
         let mut flags = self.string_flags.write().await;
         if flags.contains_key(&flag.id) {
             flags.insert(flag.id.clone(), flag);
             Ok(())
         } else {
-            Err("StringFlag not found.".to_string())
+            Err(StorageError::NotFound)
         }
     }
 
-    pub async fn delete_string_flag(&self, id: &str) -> bool {
+    async fn delete_string_flag(&self, id: &str) -> Result<bool, StorageError> {
         let mut flags = self.string_flags.write().await;
-        flags.remove(id).is_some()
+        Ok(flags.remove(id).is_some())
     }
 
-    pub async fn list_string_flags(&self, page: usize, page_size: usize) -> (Vec<StringFlag>, i32) {
+    async fn list_string_flags(
+        &self,
+        page: usize,
+        page_size: usize,
+    ) -> Result<(Vec<StringFlag>, i32), StorageError> {
         let flags = self.string_flags.read().await;
         let flags_vec: Vec<StringFlag> = flags.values().cloned().collect();
         let total_count = flags_vec.len() as i32;
@@ -105,6 +117,6 @@ impl InMemoryStorage {
         let start = page * page_size;
         let flags_page = flags_vec.into_iter().skip(start).take(page_size).collect();
 
-        (flags_page, total_count)
+        Ok((flags_page, total_count))
     }
 }

--- a/backend/src/storage/in_memory.rs
+++ b/backend/src/storage/in_memory.rs
@@ -1,0 +1,10 @@
+use proto::gen::*;
+use std::collections::HashMap;
+use tokio::sync::RwLock;
+
+// Define InMemoryStorage
+#[derive(Debug, Default)]
+pub struct InMemoryStorage {
+    bool_flags: RwLock<HashMap<String, BoolFlag>>,
+    string_flags: RwLock<HashMap<String, StringFlag>>,
+}

--- a/backend/src/storage/mod.rs
+++ b/backend/src/storage/mod.rs
@@ -1,0 +1,4 @@
+pub mod in_memory;
+pub mod prelude;
+
+pub use in_memory::InMemoryStorage;

--- a/backend/src/storage/prelude.rs
+++ b/backend/src/storage/prelude.rs
@@ -1,0 +1,1 @@
+pub trait StorageProvider {}

--- a/backend/src/storage/prelude.rs
+++ b/backend/src/storage/prelude.rs
@@ -1,1 +1,54 @@
-pub trait StorageProvider {}
+use async_trait::async_trait;
+use thiserror::Error;
+use proto::gen::*;
+
+#[derive(Debug, Error)]
+pub enum StorageError {
+    #[error("Resource not found")]
+    NotFound,
+    #[error("Resource already exists")]
+    AlreadyExists,
+    #[error("Database error: {0}")]
+    DatabaseError(String),
+    #[error("Other error: {0}")]
+    Other(String),
+}
+
+impl From<StorageError> for tonic::Status {
+    fn from(value: StorageError) -> Self {
+        match value {
+            StorageError::NotFound => tonic::Status::not_found("Resource not found"),
+            StorageError::AlreadyExists => tonic::Status::already_exists("Resource already exists"),
+            StorageError::DatabaseError(msg) => tonic::Status::internal(msg),
+            StorageError::Other(msg) => tonic::Status::internal(msg),
+        }
+    }
+}
+
+
+#[async_trait]
+pub trait StorageProvider: Send + Sync {
+    // BoolFlag methods
+    async fn create_bool_flag(&self, flag: BoolFlag) -> Result<(), StorageError>;
+    async fn get_bool_flag(&self, id: &str) -> Result<Option<BoolFlag>, StorageError>;
+    async fn get_bool_flag_by_name(&self, name: &str) -> Result<Option<BoolFlag>, StorageError>;
+    async fn update_bool_flag(&self, flag: BoolFlag) -> Result<(), StorageError>;
+    async fn delete_bool_flag(&self, id: &str) -> Result<bool, StorageError>;
+    async fn list_bool_flags(
+        &self,
+        page: usize,
+        page_size: usize,
+    ) -> Result<(Vec<BoolFlag>, i32), StorageError>;
+
+    // StringFlag methods
+    async fn create_string_flag(&self, flag: StringFlag) -> Result<(), StorageError>;
+    async fn get_string_flag(&self, id: &str) -> Result<Option<StringFlag>, StorageError>;
+    async fn get_string_flag_by_name(&self, name: &str) -> Result<Option<StringFlag>, StorageError>;
+    async fn update_string_flag(&self, flag: StringFlag) -> Result<(), StorageError>;
+    async fn delete_string_flag(&self, id: &str) -> Result<bool, StorageError>;
+    async fn list_string_flags(
+        &self,
+        page: usize,
+        page_size: usize,
+    ) -> Result<(Vec<StringFlag>, i32), StorageError>;
+}

--- a/backend/src/storage/prelude.rs
+++ b/backend/src/storage/prelude.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use async_trait::async_trait;
 use thiserror::Error;
 use proto::gen::*;
@@ -27,7 +28,7 @@ impl From<StorageError> for tonic::Status {
 
 
 #[async_trait]
-pub trait StorageProvider: Send + Sync {
+pub trait StorageProvider: Send + Sync + Debug {
     // BoolFlag methods
     async fn create_bool_flag(&self, flag: BoolFlag) -> Result<(), StorageError>;
     async fn get_bool_flag(&self, id: &str) -> Result<Option<BoolFlag>, StorageError>;


### PR DESCRIPTION
In order to facilitate the creation of different storage backends, we introduce the `StorageProvider` trait, which defines the behaviors required from a given storage backend. Currently the only implementation of this is `InMemoryStorage`, but this should allow others to more easily provide a redis implementation, for example.